### PR TITLE
Formatting added to manifest file

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,1 +1,353 @@
-{"timestamp":"2021-06-06T18:51:06+00:00","children":[{"name":"Aliases","path":"Aliases","type":"category","children":[{"path":"Aliases/External-aliases.fsh","name":"External Aliases","description":"Common aliases based on package hl7.terminology#2.1.0 based on FHIR 4.0.1. Generated 2021-03-06. Leading $ signs are optional but are useful for visually distinguishing aliases from other names. Both versions are provided.","type":"file"},{"path":"Aliases/FHIR-aliases.fsh","name":"FHIR Aliases","description":"Code system defined by FHIR from terminology.hl7.org","type":"file"},{"path":"Aliases/US-Core-aliases.fsh","name":"US Core Aliases ","type":"file"}]},{"name":"Code Systems","path":"Code%20Systems","type":"category","children":[{"path":"Code%20Systems/Local-codes.fsh","name":"Local Code Systems","type":"file"}]},{"name":"Extensions","path":"Extensions","type":"category","children":[{"path":"Extensions/Complex-extension.fsh","name":"Complex Extensions","description":"Examples of extensions with sub-extensions. Note that an extension cannot have BOTH a value and extensions.","type":"file"},{"path":"Extensions/Simple-extension.fsh","name":"Simple Extensions","description":"Examples of extensions with values (no sub-extensions)","type":"file"}]},{"name":"Instances","path":"Instances","type":"category","children":[{"path":"Instances/Instance-example.fsh","name":"Instance Example","type":"file"}]},{"name":"Invariants","path":"Invariants","type":"category","children":[{"path":"Invariants/Date-format-regex.fsh","name":"Date Format Regex","description":"Example of regular expression that limits dateTime element to Dates (YYYY-MM-DD only)","type":"file"},{"path":"Invariants/Require-element-OR.fsh","name":"Require Element OR","description":"Invariant requiring one or both of two elements to be present","type":"file"},{"path":"Invariants/Require-element-XOR.fsh","name":"Require Element XOR","description":"Invariant requiring one of two elements to be present (not both)","type":"file"},{"path":"Invariants/String-length-invariant.fsh","name":"String Length Invariant","description":"Limit string length invariant","type":"file"}]},{"name":"Mappings","path":"Mappings","type":"category","children":[{"path":"Mappings/mapping-example.fsh","name":"Mapping Example","type":"file"}]},{"name":"Paths","path":"Paths","type":"category","children":[{"path":"Paths/Array-element-paths.fsh","name":"Array-element-paths","type":"file"},{"path":"Paths/Caret-paths.fsh","name":"Caret-paths","type":"file"},{"path":"Paths/Extension-paths.fsh","name":"Extension-paths","type":"file"},{"path":"Paths/Reference-paths.fsh","name":"Reference-paths","type":"file"},{"path":"Paths/Sliced-array-paths.fsh","name":"Sliced-array-paths","type":"file"},{"path":"Paths/Soft-indexing-paths.fsh","name":"Soft-indexing-paths","type":"file"}]},{"name":"Profiles","path":"Profiles","type":"category","children":[{"path":"Profiles/Profile-example.fsh","name":"Profile-example","type":"file"}]},{"name":"Rule Sets","path":"Rule%20Sets","type":"category","children":[{"name":"Parameterized","path":"Rule%20Sets/Parameterized","type":"category","children":[{"path":"Rule%20Sets/Parameterized/Capability-statement-rules.fsh","description":"Rules to populate a CapabilityStatement","type":"file"},{"path":"Rule%20Sets/Parameterized/Create-observation-component.fsh","name":"Create Observation Component","description":"Create Observation components easily using RuleSets","type":"file"},{"path":"Rule%20Sets/Parameterized/Set-extension-context.fsh","name":"Set Extension Context","description":"Specify which resources or elements an extension can be applied to","type":"file"},{"path":"Rule%20Sets/Parameterized/Set-short-and-definition.fsh","name":"Set Short and Definition","description":"Rule set to set the short name and definition for any element","type":"file"},{"path":"Rule%20Sets/Parameterized/Using-soft-indexing.fsh","name":"Using Soft Indexing","description":"Parameterized rule set using soft indexing","type":"file"}]},{"name":"Simple","path":"Rule%20Sets/Simple","type":"category","children":[{"path":"Rule%20Sets/Simple/Shared-radiotherapy-rules.fsh","name":"Shared Radiotherapy Rules","description":"Share a set of rules among multiple profiles","type":"file"}]},{"name":"Slicing","path":"Rule%20Sets/Slicing","type":"category","children":[{"path":"Rule%20Sets/Slicing/Bundle-slice-on-profile.fsh","name":"Bundle Slice on Profile","description":"RuleSet for slicing a Bundle on the profile of referenced resource","type":"file"},{"path":"Rule%20Sets/Slicing/Category-slicing.fsh","name":"Category Slicing","description":"Slice the category element so a certain category is required","type":"file"},{"path":"Rule%20Sets/Slicing/Observation-component-slicing.fsh","name":"Observation Component Slicing","description":"RuleSet for Slicing Observation.component","type":"file"},{"path":"Rule%20Sets/Slicing/Observation-has-member-slice-on-code.fsh","name":"Observation hasMember Slice on Code","description":"RuleSet for Slicing Observation.hasMember on an element's value in the referenced resource","type":"file"}]}]},{"name":"Rules","path":"Rules","type":"category","children":[{"name":"Contains","path":"Rules/Contains","type":"category","children":[{"name":"Slicing","path":"Rules/Contains/Slicing","type":"category","children":[{"path":"Rules/Contains/Slicing/Slicing-identifier-element.fsh","name":"Slicing Identifier Element","description":"Slice the identifier to require an implementer to support lab results accession number, filler order number and placer order number","type":"file"}]}]},{"name":"Flags","path":"Rules/Flags","type":"category","children":[{"path":"Rules/Flags/Must-support-declarations.fsh","name":"Must Support Declarations","description":"Basic Must Support declarations","type":"file"},{"path":"Rules/Flags/Must-support-on-resource-or-profile.fsh","name":"Must Support on Resource or Profile","description":"Put a MS flag on a profile (as opposed to an element in the profile)","type":"file"},{"path":"Rules/Flags/Must-support-on-selected-referenced-resource.fsh","name":"Must Support on Selected Referenced Resource","description":"Apply an MS flag to a Reference, for example, in Reference(Patient or Practitioner), put MS on Practitioner without a MS on Patient. ","type":"file"}]}]},{"name":"Value Sets","path":"Value%20Sets","type":"category","children":[{"path":"Value%20Sets/Exclude-single-codes.fsh","name":"Exclude Single Codes","description":"Value set with includes and excludes","type":"file"},{"path":"Value%20Sets/Include-entire-code-system.fsh","name":"Include Entire Code System","description":"Value set comprised of an entire code system","type":"file"},{"path":"Value%20Sets/Include-entire-value-set.fsh","name":"Include Entire Value Set","description":"A value set containing other value sets","type":"file"},{"path":"Value%20Sets/Include-rules.fsh","name":"Include Rules","description":"Value set illustrating various include rules","type":"file"},{"path":"Value%20Sets/Include-single-codes.fsh","name":"Include Single Codes","description":"Value set with explicit codes","type":"file"},{"path":"Value%20Sets/LOINC-filtering.fsh","name":"LOINC Filtering","description":"Value set example filtering on LOINC Part (LP) codes","type":"file"},{"path":"Value%20Sets/SNOMED-filtering.fsh","name":"SNOMED Filtering","description":"Value set with includes and excludes","type":"file"}]}]}
+{
+	"timestamp": "2021-06-06T19:11:10+00:00",
+	"children": [
+		{
+			"name": "Aliases",
+			"path": "Aliases",
+			"type": "category",
+			"children": [
+				{
+					"path": "Aliases/External-aliases.fsh",
+					"name": "External Aliases",
+					"description": "Common aliases based on package hl7.terminology#2.1.0 based on FHIR 4.0.1. Generated 2021-03-06. Leading $ signs are optional but are useful for visually distinguishing aliases from other names. Both versions are provided.",
+					"type": "file"
+				},
+				{
+					"path": "Aliases/FHIR-aliases.fsh",
+					"name": "FHIR Aliases",
+					"description": "Code system defined by FHIR from terminology.hl7.org",
+					"type": "file"
+				},
+				{
+					"path": "Aliases/US-Core-aliases.fsh",
+					"name": "US Core Aliases",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Code Systems",
+			"path": "Code%20Systems",
+			"type": "category",
+			"children": [
+				{
+					"path": "Code%20Systems/Local-codes.fsh",
+					"name": "Local Code Systems",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Extensions",
+			"path": "Extensions",
+			"type": "category",
+			"children": [
+				{
+					"path": "Extensions/Complex-extension.fsh",
+					"name": "Complex Extensions",
+					"description": "Examples of extensions with sub-extensions. Note that an extension cannot have BOTH a value and extensions.",
+					"type": "file"
+				},
+				{
+					"path": "Extensions/Simple-extension.fsh",
+					"name": "Simple Extensions",
+					"description": "Examples of extensions with values (no sub-extensions)",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Instances",
+			"path": "Instances",
+			"type": "category",
+			"children": [
+				{
+					"path": "Instances/Instance-example.fsh",
+					"name": "Instance Example",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Invariants",
+			"path": "Invariants",
+			"type": "category",
+			"children": [
+				{
+					"path": "Invariants/Date-format-regex.fsh",
+					"name": "Date Format Regex",
+					"description": "Example of regular expression that limits dateTime element to Dates (YYYY-MM-DD only)",
+					"type": "file"
+				},
+				{
+					"path": "Invariants/Require-element-OR.fsh",
+					"name": "Require Element OR",
+					"description": "Invariant requiring one or both of two elements to be present",
+					"type": "file"
+				},
+				{
+					"path": "Invariants/Require-element-XOR.fsh",
+					"name": "Require Element XOR",
+					"description": "Invariant requiring one of two elements to be present (not both)",
+					"type": "file"
+				},
+				{
+					"path": "Invariants/String-length-invariant.fsh",
+					"name": "String Length Invariant",
+					"description": "Limit string length invariant",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Mappings",
+			"path": "Mappings",
+			"type": "category",
+			"children": [
+				{
+					"path": "Mappings/mapping-example.fsh",
+					"name": "Mapping Example",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Paths",
+			"path": "Paths",
+			"type": "category",
+			"children": [
+				{
+					"path": "Paths/Array-element-paths.fsh",
+					"name": "Array-element-paths",
+					"type": "file"
+				},
+				{
+					"path": "Paths/Caret-paths.fsh",
+					"name": "Caret-paths",
+					"type": "file"
+				},
+				{
+					"path": "Paths/Extension-paths.fsh",
+					"name": "Extension-paths",
+					"type": "file"
+				},
+				{
+					"path": "Paths/Reference-paths.fsh",
+					"name": "Reference-paths",
+					"type": "file"
+				},
+				{
+					"path": "Paths/Sliced-array-paths.fsh",
+					"name": "Sliced-array-paths",
+					"type": "file"
+				},
+				{
+					"path": "Paths/Soft-indexing-paths.fsh",
+					"name": "Soft-indexing-paths",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Profiles",
+			"path": "Profiles",
+			"type": "category",
+			"children": [
+				{
+					"path": "Profiles/Profile-example.fsh",
+					"name": "Profile-example",
+					"type": "file"
+				}
+			]
+		},
+		{
+			"name": "Rule Sets",
+			"path": "Rule%20Sets",
+			"type": "category",
+			"children": [
+				{
+					"name": "Parameterized",
+					"path": "Rule%20Sets/Parameterized",
+					"type": "category",
+					"children": [
+						{
+							"path": "Rule%20Sets/Parameterized/Capability-statement-rules.fsh",
+							"name": "CapabilityStatement Rules",
+							"description": "Rules to populate a CapabilityStatement",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Parameterized/Create-observation-component.fsh",
+							"name": "Create Observation Component",
+							"description": "Create Observation components easily using RuleSets",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Parameterized/Set-extension-context.fsh",
+							"name": "Set Extension Context",
+							"description": "Specify which resources or elements an extension can be applied to",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Parameterized/Set-short-and-definition.fsh",
+							"name": "Set Short and Definition",
+							"description": "Rule set to set the short name and definition for any element",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Parameterized/Using-soft-indexing.fsh",
+							"name": "Using Soft Indexing",
+							"description": "Parameterized rule set using soft indexing",
+							"type": "file"
+						}
+					]
+				},
+				{
+					"name": "Simple",
+					"path": "Rule%20Sets/Simple",
+					"type": "category",
+					"children": [
+						{
+							"path": "Rule%20Sets/Simple/Shared-radiotherapy-rules.fsh",
+							"name": "Shared Radiotherapy Rules",
+							"description": "Share a set of rules among multiple profiles",
+							"type": "file"
+						}
+					]
+				},
+				{
+					"name": "Slicing",
+					"path": "Rule%20Sets/Slicing",
+					"type": "category",
+					"children": [
+						{
+							"path": "Rule%20Sets/Slicing/Bundle-slice-on-profile.fsh",
+							"name": "Bundle Slice on Profile",
+							"description": "RuleSet for slicing a Bundle on the profile of referenced resource",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Slicing/Category-slicing.fsh",
+							"name": "Category Slicing",
+							"description": "Slice the category element so a certain category is required",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Slicing/Observation-component-slicing.fsh",
+							"name": "Observation Component Slicing",
+							"description": "RuleSet for Slicing Observation.component",
+							"type": "file"
+						},
+						{
+							"path": "Rule%20Sets/Slicing/Observation-has-member-slice-on-code.fsh",
+							"name": "Observation hasMember Slice on Code",
+							"description": "RuleSet for Slicing Observation.hasMember on an element's value in the referenced resource",
+							"type": "file"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Rules",
+			"path": "Rules",
+			"type": "category",
+			"children": [
+				{
+					"name": "Contains",
+					"path": "Rules/Contains",
+					"type": "category",
+					"children": [
+						{
+							"name": "Slicing",
+							"path": "Rules/Contains/Slicing",
+							"type": "category",
+							"children": [
+								{
+									"path": "Rules/Contains/Slicing/Slicing-identifier-element.fsh",
+									"name": "Slicing Identifier Element",
+									"description": "Slice the identifier to require an implementer to support lab results accession number, filler order number and placer order number",
+									"type": "file"
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Flags",
+					"path": "Rules/Flags",
+					"type": "category",
+					"children": [
+						{
+							"path": "Rules/Flags/Must-support-declarations.fsh",
+							"name": "Must Support Declarations",
+							"description": "Basic Must Support declarations",
+							"type": "file"
+						},
+						{
+							"path": "Rules/Flags/Must-support-on-resource-or-profile.fsh",
+							"name": "Must Support on Resource or Profile",
+							"description": "Put a MS flag on a profile (as opposed to an element in the profile)",
+							"type": "file"
+						},
+						{
+							"path": "Rules/Flags/Must-support-on-selected-referenced-resource.fsh",
+							"name": "Must Support on Selected Referenced Resource",
+							"description": "Apply an MS flag to a Reference, for example, in Reference(Patient or Practitioner), put MS on Practitioner without a MS on Patient.",
+							"type": "file"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Value Sets",
+			"path": "Value%20Sets",
+			"type": "category",
+			"children": [
+				{
+					"path": "Value%20Sets/Exclude-single-codes.fsh",
+					"name": "Exclude Single Codes",
+					"description": "Value set with includes and excludes",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/Include-entire-code-system.fsh",
+					"name": "Include Entire Code System",
+					"description": "Value set comprised of an entire code system",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/Include-entire-value-set.fsh",
+					"name": "Include Entire Value Set",
+					"description": "A value set containing other value sets",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/Include-rules.fsh",
+					"name": "Include Rules",
+					"description": "Value set illustrating various include rules",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/Include-single-codes.fsh",
+					"name": "Include Single Codes",
+					"description": "Value set with explicit codes",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/LOINC-filtering.fsh",
+					"name": "LOINC Filtering",
+					"description": "Value set example filtering on LOINC Part (LP) codes",
+					"type": "file"
+				},
+				{
+					"path": "Value%20Sets/SNOMED-filtering.fsh",
+					"name": "SNOMED Filtering",
+					"description": "Value set with includes and excludes",
+					"type": "file"
+				}
+			]
+		}
+	]
+}

--- a/manifest.js
+++ b/manifest.js
@@ -17,11 +17,11 @@ async function getMetadata(filePath, fileName) {
   const parseLines = async () => {
     for await (const line of lineReader) {
       if (line.includes('@Name:')) {
-        const splitLine = line.split('@Name: ');
-        metaData.name = splitLine[1];
+        const splitLine = line.split('@Name:');
+        metaData.name = splitLine[1].trim();
       } else if (line.includes('@Description')) {
-        const splitLine = line.split('@Description: ');
-        metaData.description = splitLine[1];
+        const splitLine = line.split('@Description:');
+        metaData.description = splitLine[1].trim();
       }
       if (Object.keys(metaData).length == 2) return;
     }
@@ -76,7 +76,7 @@ async function getChildren(baseDirName) {
 async function generateManifest() {
   const examplesArr = await getChildren(path.join(__dirname, 'Examples'));
   let manifestObj = {timestamp: moment(Date.now()).format(), children: examplesArr };
-  fs.writeFileSync(manifestPath, JSON.stringify(manifestObj), 'utf-8');
+  fs.writeFileSync(manifestPath, JSON.stringify(manifestObj, null, "\t"), 'utf-8');
 }
 
 generateManifest();


### PR DESCRIPTION
Simply adds formatting to the generated manifest file, hopefully allaying any merge conflicts. Also allows the `@Name:` and `@Description:` tags to be picked up when there are no spaces included after the tag. 