### PR TITLE
Fix CapabilityStatement RuleSets

### DIFF
--- a/Examples/Rule Sets/Parameterized/Capability-statement-rules.fsh
+++ b/Examples/Rule Sets/Parameterized/Capability-statement-rules.fsh
@@ -12,22 +12,22 @@ RuleSet: SupportResource (resource, expectation)
 RuleSet: SupportProfile (profile, expectation)
 // This rule set must follow a SupportResource rule set, and applies to that resource.
 * rest.resource[=].supportedProfile[+] = "{profile}"
-* rest.resource[=].extension[0].url = $exp
-* rest.resource[=].extension[0].valueCode = {expectation}
+* rest.resource[=].supportedProfile[=].extension[0].url = $exp
+* rest.resource[=].supportedProfile[=].extension[0].valueCode = {expectation}
 
 RuleSet: SupportInteraction (interaction, expectation)
 // This rule set must follow a SupportResource rule set, and applies to that resource.
 * rest.resource[=].interaction[+].code = {interaction}
-* rest.resource[=].extension[0].url = $exp
-* rest.resource[=].extension[0].valueCode = {expectation}
+* rest.resource[=].interaction[=].extension[0].url = $exp
+* rest.resource[=].interaction[=].extension[0].valueCode = {expectation}
 
 RuleSet: SupportSearchParam (name, canonical, type, expectation)
 // This rule set must follow a SupportResource rule set, and applies to that resource.
 * rest.resource[=].searchParam[+].name = "{name}"
 * rest.resource[=].searchParam[=].definition = "{canonical}"
 * rest.resource[=].searchParam[=].type = {type}
-* rest.resource[=].extension[0].url = $exp
-* rest.resource[=].extension[0].valueCode = {expectation}
+* rest.resource[=].searchParam[=].extension[0].url = $exp
+* rest.resource[=].searchParam[=].extension[0].valueCode = {expectation}
 
 
 Instance: ExampleCapabilityStatement

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2021-07-21T10:45:53+00:00",
+	"timestamp": "2021-09-25T22:24:01+00:00",
 	"children": [
 		{
 			"name": "Aliases",


### PR DESCRIPTION
The rulesets for profile, interaction, and searchparam incorrectly set the expectation at the resource level instead of at their own respective levels.