### PR TITLE
Remove trailing comma from JSON

### DIFF
--- a/index.json
+++ b/index.json
@@ -91,7 +91,7 @@
 					"name": "Contained Instance Example",
 					"description": "An example of an instance that contains another instance which references its container",
 					"type": "file"
-				},
+				}
 			]
 		},
 		{

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2022-04-07T15:57:45+00:00",
+	"timestamp": "2023-08-03T19:56:07+00:00",
 	"children": [
 		{
 			"name": "Aliases",
@@ -81,15 +81,15 @@
 			"type": "category",
 			"children": [
 				{
-					"path": "Instances/Instance-example.fsh",
-					"name": "Instance Example",
-					"description": "An example of an instance of a Patient resource",
-					"type": "file"
-				},
-				{
 					"path": "Instances/Instance-contained-example.fsh",
 					"name": "Contained Instance Example",
 					"description": "An example of an instance that contains another instance which references its container",
+					"type": "file"
+				},
+				{
+					"path": "Instances/Instance-example.fsh",
+					"name": "Instance Example",
+					"description": "An example of an instance of a Patient resource",
 					"type": "file"
 				}
 			]


### PR DESCRIPTION
Just removes a trailing comma, which makes the JSON file sad and FSH Online cannot parse it.