### PR TITLE
Fix typo at the end of Description in Abstract-profile.fsh

### DIFF
--- a/Examples/Profiles/Abstract-profile.fsh
+++ b/Examples/Profiles/Abstract-profile.fsh
@@ -5,7 +5,7 @@ Profile:     ExampleAbstractPatientProfile
 Id:          example-abstract-patient-profile
 Parent:      Patient
 Title:       "Example Abstract Patient Profile"
-Description: "Example of an abstract profile of Patient"m
+Description: "Example of an abstract profile of Patient"
 * ^abstract = true // For more information see http://www.hl7.org/fhir/structuredefinition-definitions.html#StructureDefinition.abstract
 * name 1..* // Require at least one value inside the `name` element
 * name and name.given and name.family MS // Mark elements as MustSupport

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2023-08-03T19:56:07+00:00",
+	"timestamp": "2023-09-14T18:17:01+00:00",
 	"children": [
 		{
 			"name": "Aliases",


### PR DESCRIPTION
Small PR for a minor typo I noticed in the "Abstract Profile" example, which causes an error in the FSH when used directly.

For quick reference, a FSH Online link with the broken FSH is [here](https://fshschool.org/FSHOnline/#/share/468ZSUk) and the updated FSH from this PR is [here](https://fshschool.org/FSHOnline/#/share/46dsFHA).