### PR TITLE
Best Practices

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,3 @@
+**Description:**
+
+**Related Issue:**

--- a/BEST-PRACTICES.md
+++ b/BEST-PRACTICES.md
@@ -1,0 +1,43 @@
+# Best Practices
+
+We're glad you're considering contributing to FSH Online Examples! Below are a few best practices that we recommend for all contributions.
+
+## Before Contributing
+
+Before contributing a feature or a bugfix, we recommend creating a GitHub issue if one does not exist. This allows the community to provide feedback on why an issue may be occurring or provide additional insight into a suggested feature. See the [Contribution Policy](CONTRIBUTING.md#issues) to learn more about creating issues. It may also be useful, but is not required, to start a Zulip conversation around the feature or bug. See the [Contribution Policy](CONTRIBUTING.md#zulip) to learn more about Zulip.
+
+If a GitHub issue already exists for what you are planning to contribute, we recommend commenting on the issue to indicate that you are working on an implementation to avoid duplication of work.
+
+## Coding Practices
+
+We recommend the following coding practices for high quality contributions:
+
+- Make all changes in a personal [fork](https://help.github.com/articles/fork-a-repo/) of this repository.
+- Use descriptive commit messages.
+- FSH examples should follow FSH best practices. Examples should not produce errors or warnings when used in FSH Online.
+- Include comments in FSH examples as needed to clarify examples.
+- Ensure any new dependencies use the latest published version.
+  - If a new dependency is required but the latest published version cannot be used, add the dependency and reason for not updating to [DEPENDENCY-NOTES.md](DEPENDENCY-NOTES.md).
+  - To check the latest published version, check the versions of the package on [npm](https://www.npmjs.com/) or use [npm-outdated](https://docs.npmjs.com/cli/v10/commands/npm-outdated). Run `npm outdated` and check that the new dependency is not listed in the output.
+- Ensure any new dependencies do not contain any known security vulnerabilities
+  - To check for known security vulnerabilities, we recommend using [npm-audit](https://docs.npmjs.com/cli/v10/commands/npm-audit). Run `npm audit` and ensure there are no new issues on your branch.
+- Update documentation to reflect any user-facing changes.
+  - Documentation updates may include, but are not limited to, the project [README](README.md).
+
+## Making a Pull Request
+
+We recommend the following best practices for creating a high quality pull request:
+
+- Review your own PR before marking it as ready for review by others. Ensure the only code changes included are ones relevant to the feature or bugfix and that they follow the coding practices outlined above.
+- Ensure your branch is up to date with master. There are a few ways you can update your branch:
+  - Use the "Update branch" button available once you make your PR. This is the recommended approach if you are not comfortable with merging or rebasing.
+  - [Merge](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging) master into your branch.
+  - [Rebase](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) your branch on master. We only recommend this approach if you are very comfortable with rebasing.
+- Update the title of the PR to provide a short, descriptive summary of the PR.
+  - Keep the title up to date with any changes made during the review process. The title will be used in the commit message and in the release notes, so it is important that it accurately reflects the current state of the PR.
+- Follow the pull request template to create a detailed PR description.
+  - Include a detailed description of the changes made in the PR.
+  - Include instructions for how to test the PR. You may want to include a link to sample FSH in FSH Online to demonstrate a bug or attach a sample project that highlights new or improved behavior.
+  - [Link the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) that the PR addresses.
+- Follow up on any discussion on your PR. If changes are requested, make any necessary updates and comment indicating your PR is ready for re-review.
+- If your PR is approved, it will be merged to master using the "[squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)" strategy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Before making a contribution, please familiarize yourself with this document, as
 
 ## Issues
 
-We use GitHub issues to track bug reports, comments, suggestions, questions, and feature requests.
+We use GitHub issues to track bug reports, comments, suggestions, questions, and feature requests. If you need help with using FHIR Shorthand or its tools, however, you may want to consider posting on Zulip first (see below). Questions posted on Zulip will reach a broader set of FSH users and will likely receive more timely responses. Requests for specific changes, however, should be submitted as GitHub issues so they can be formally tracked.
 
 Before submitting a new issue, please check to make sure a similar issue isn't already open. If one is, contribute to that issue thread with your feedback.
 
@@ -26,6 +26,8 @@ When submitting a bug report, please try to provide as much detail as possible. 
 - the full text of error messages
 - relevant outputs
 - any other information you deem relevant
+
+When creating or contributing to an issue, please include a link to any relevant discussion threads on Zulip (see below).
 
 Please note that the GitHub issue tracker is _public_; any issues you submit are immediately visible to everyone. For this reason, do _not_ submit any information that may be considered sensitive.
 
@@ -39,6 +41,8 @@ Before starting a new conversation, please check for earlier discussions on a si
 
 When starting a new conversation, please use a descriptive topic and include as much detail as possible.
 
+If you are looking for feedback or discussion around an issue, we recommend using Zulip. The FSH community is active on Zulip, and it is the best place to have in-depth discussions and ask questions about the FSH tooling. If the discussion on Zulip determines that a change is required in FSH Online Examples, you should create a GitHub issue to track it. The GitHub issue should include a link to the relevant Zulip discussion thread, and it is best practice to provide a link to the GitHub issue on the Zulip thread. While Zulip is very useful for discussion, GitHub issues are the system of record for changes to FSH Online Examples.
+
 ## Code Contributions
 
 If you are planning to work on a reported bug, suggestion, or feature request, please comment on the relevant issue to indicate your intent to work on it.
@@ -47,7 +51,7 @@ This reduces the likelihood of duplicated effort and also provides the maintaine
 
 ### Coding Practices
 
-Code that is contributed to this project should be done in a personal fork of this repository and follow the coding practices specified in our Best Practices documentation (coming soon!).
+Code that is contributed to this project should be done in a personal fork of this repository and follow the coding practices specified in our Best Practices documentation in [BEST-PRACTICES.md](BEST-PRACTICES.md).
 
 If you are planning to add to the set of FSH Examples, the [README](README.md#example-submissions) provides step by step instructions for how to create a fork for your work, where to add the FSH for your example, and how to create a pull request.
 

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2024-06-13T21:09:45+00:00",
+	"timestamp": "2024-06-21T17:55:08+00:00",
 	"children": [
 		{
 			"name": "Aliases",


### PR DESCRIPTION
This PR adds the Best Practice document, a PR template, and updates the Contributing document with the latest updates.

This Best Practice document removes the coding practices around self-explanatory code (since this is pretty much just FSH examples, not code), unit tests, lint, and prettier (since all 3 do not exist in this repo). I did add two best practices around contributing examples:

> - FSH examples should follow FSH best practices. Examples should not produce errors or warnings when used in FSH Online.
> - Include comments in FSH examples as needed to clarify examples.

It also removes the mention of updating FSH School documentation since that isn't applicable to this repo.

I also removed the "Testing Instructions" section of the PR template since contributions will likely just need to review the FSH added, so there likely aren't many other testing instructions needed.