### PR TITLE
Move FSHOnline-Examples to GitHub FHIR organization

### DIFF
--- a/Examples/Aliases/HL7-code-systems-V2-aliases.fsh
+++ b/Examples/Aliases/HL7-code-systems-V2-aliases.fsh
@@ -1,5 +1,5 @@
 // @Name: HL7 V2 aliases (complete)
-// @Description: Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
+// @Description: Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
 
 Alias:   $v2-accept-applicationAcknowledgmentConditions = http://terminology.hl7.org/CodeSystem/v2-0155 // accept-applicationAcknowledgmentConditions
 Alias:   $v2-accessRestrictionValue                     = http://terminology.hl7.org/CodeSystem/v2-0717 // accessRestrictionValue

--- a/Examples/Aliases/HL7-code-systems-V3-aliases.fsh
+++ b/Examples/Aliases/HL7-code-systems-V3-aliases.fsh
@@ -1,5 +1,5 @@
 // @Name: HL7 V3 aliases (complete)
-// @Description: Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
+// @Description: Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
 
 Alias:   $v3-AcknowledgementCondition            = http://terminology.hl7.org/CodeSystem/v3-AcknowledgementCondition              // AcknowledgementCondition
 Alias:   $v3-AcknowledgementDetailCode           = http://terminology.hl7.org/CodeSystem/v3-AcknowledgementDetailCode             // AcknowledgementDetailCode

--- a/Examples/Aliases/HL7-code-systems-other-aliases.fsh
+++ b/Examples/Aliases/HL7-code-systems-other-aliases.fsh
@@ -1,5 +1,5 @@
 // @Name: HL7 other aliases (complete)
-// @Description: Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
+// @Description: Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.
 
 Alias:   $ACR                                            = http://terminology.hl7.org/CodeSystem/ACR                                            // American College of Radiology finding codes
 Alias:   $AS4                                            = http://terminology.hl7.org/CodeSystem/AS4                                            // ASTM E1238/ E1467 Universal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # FSHOnline-Examples
 
-This repository contains a set of FHIR Shorthand examples that are displayed on [FSH Online](https://fshschool.org/FSHOnline/). 
+This repository contains a set of FHIR Shorthand examples that are displayed on [FSH Online](https://fshonline.fshschool.org/). 
 The goal of these examples is to demonstrate various aspects of FHIR Shorthand, ranging from basic examples to complex concepts. FSH authors are encouraged to submit their own examples to be used by the FSH community. Each example should ideally demonstrate a feature of FSH that isn't covered by other examples.
 
 ## FHIR Foundation Project Statement
 
 - Maintainers: This project is maintained by the HL7 community.
-- Issues / Discussion: For FHIR Shorthand examples issues, such as bug reports, comments, suggestions, questions, and feature requests, visit [FHIR Shorthand examples GitHub Issues](https://github.com/FSHSchool/FSHOnline-Examples/issues). For discussion of FHIR Shorthand and its associated projects, visit the FHIR Community Chat @ https://chat.fhir.org. The [#shorthand stream](https://chat.fhir.org/#narrow/stream/215610-shorthand) is used for all FHIR Shorthand questions and discussion.
+- Issues / Discussion: For FHIR Shorthand examples issues, such as bug reports, comments, suggestions, questions, and feature requests, visit [FHIR Shorthand examples GitHub Issues](https://github.com/FHIR/FSHOnline-Examples/issues). For discussion of FHIR Shorthand and its associated projects, visit the FHIR Community Chat @ https://chat.fhir.org. The [#shorthand stream](https://chat.fhir.org/#narrow/stream/215610-shorthand) is used for all FHIR Shorthand questions and discussion.
 - License: All contributions to this project will be released under the Apache 2.0 License, and a copy of this license can be found in [LICENSE](LICENSE).
 - Contribution Policy: The FHIR Shorthand examples Contribution Policy can be found in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Security Information: The FHIR Shorthand examples Security Information can be found in [SECURITY.md](SECURITY.md).
@@ -22,7 +22,7 @@ Examples should be submitted by way of pull requests on this repository. Submiss
 5. After completing all changes, stage and commit your work.
 6. Push your commit to Github with the following command: `git push —set-upstream origin <your-branch-name>`
 7. Navigate to the FSHOnline-Examples repository on Github and then click on “Pull requests”.
-8. Click on “New pull request”, then "compare across forks". Select `main` as the base branch, `FSHSchool/FSHOnline-Examples` as the base repository, your forked repository as the head repository, and your feature branch as the compare branch. Then, click “Create pull request”.
+8. Click on “New pull request”, then "compare across forks". Select `main` as the base branch, `FHIR/FSHOnline-Examples` as the base repository, your forked repository as the head repository, and your feature branch as the compare branch. Then, click “Create pull request”.
 9. Edit the title and description of the pull request, and then click “Create pull request”.
 
 ## Metadata Tags

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Reporting security issues privately
 
-To report a security issue privately, please [create a security advisory](https://github.com/FSHSchool/FSHOnline-Examples/security/advisories) in this repository. This will allow repository administrators to review and address it privately before public disclosure. For more details about this process, see ["Privately reporting a security vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+To report a security issue privately, please [create a security advisory](https://github.com/FHIR/FSHOnline-Examples/security/advisories) in this repository. This will allow repository administrators to review and address it privately before public disclosure. For more details about this process, see ["Privately reporting a security vulnerability"](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
 # Project security practices
 

--- a/Scripts/Aliases/HL7.ipynb
+++ b/Scripts/Aliases/HL7.ipynb
@@ -57,8 +57,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Loading code systems from \"code_systems.pickle\" cache (last updated 2021-06-15T07:02:40.951027).\n"
      ]
@@ -84,7 +84,7 @@
     "        raw = requests.get('https://terminology.hl7.org/' + l.hl7_webpage.replace('.html', '.json'), verify=False).text\n",
     "        j = json.loads(raw)\n",
     "        l.uri = j['url']\n",
-    "    \n",
+    "\n",
     "    # Cache code systems for faster future runs where a refresh is not needed\n",
     "    pickle.dump( {\"pickled_at\": datetime.datetime.now().isoformat(), \"code_systems\": code_systems}, open(\"code_systems.pickle\", \"wb\" ) )"
    ]
@@ -105,7 +105,7 @@
     "    # If this is a THO code system, use the slug from that\n",
     "    if l.uri.startswith('http://terminology.hl7.org'):\n",
     "        l.alias = l.uri.replace('http://terminology.hl7.org/CodeSystem/', '')\n",
-    "    \n",
+    "\n",
     "    # Otherwise, use the slug from the HL7 webpage filename for the code system\n",
     "    else:\n",
     "        l.alias = l.hl7_webpage.replace('CodeSystem-', '').replace('.html', '')\n",
@@ -176,8 +176,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "424 aliases written to ../../Examples/Aliases/HL7-code-systems-V2-aliases.fsh\n"
      ]
@@ -189,7 +189,7 @@
     "    [c for c in code_systems if c.alias.startswith('$v2-')],\n",
     "    path,\n",
     "    \"// @Name: HL7 V2 aliases (complete)\",\n",
-    "    f\"// @Description: Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
+    "    f\"// @Description: Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
     ")"
    ]
   },
@@ -208,8 +208,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "214 aliases written to ../../Examples/Aliases/HL7-code-systems-V3-aliases.fsh\n"
      ]
@@ -221,7 +221,7 @@
     "    [c for c in code_systems if c.alias.startswith('$v3-')],\n",
     "    path,\n",
     "    \"// @Name: HL7 V3 aliases (complete)\",\n",
-    "    f\"// @Description: Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
+    "    f\"// @Description: Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
     ")"
    ]
   },
@@ -240,8 +240,8 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "451 aliases written to ../../Examples/Aliases/HL7-code-systems-other-aliases.fsh\n"
      ]
@@ -253,7 +253,7 @@
     "    [c for c in code_systems if not c.alias.startswith('$v3-') and not c.alias.startswith('$v2-')],\n",
     "    path,\n",
     "    \"// @Name: HL7 other aliases (complete)\",\n",
-    "    f\"// @Description: Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
+    "    f\"// @Description: Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.\"\n",
     ")"
    ]
   },
@@ -266,9 +266,12 @@
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "2bec22352dfc440adadc4a94fce8c08d62d972e232a58d44637843e37dc0c0ba"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.9.5 64-bit ('Aliases-ThvkuffE': venv)"
+   "display_name": "Python 3.9.5 64-bit ('Aliases-ThvkuffE': venv)",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -281,9 +284,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.9.5"
-  },
-  "interpreter": {
-   "hash": "2bec22352dfc440adadc4a94fce8c08d62d972e232a58d44637843e37dc0c0ba"
   }
  },
  "nbformat": 4,

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2024-09-12T13:47:15+00:00",
+	"timestamp": "2024-09-13T09:48:20-04:00",
 	"children": [
 		{
 			"name": "Aliases",
@@ -21,19 +21,19 @@
 				{
 					"path": "Aliases/HL7-code-systems-V2-aliases.fsh",
 					"name": "HL7 V2 aliases (complete)",
-					"description": "Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
+					"description": "Aliases for all V2 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
 					"type": "file"
 				},
 				{
 					"path": "Aliases/HL7-code-systems-V3-aliases.fsh",
 					"name": "HL7 V3 aliases (complete)",
-					"description": "Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
+					"description": "Aliases for all V3 code systems defined at https://terminology.hl7.org/codesystems.html. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
 					"type": "file"
 				},
 				{
 					"path": "Aliases/HL7-code-systems-other-aliases.fsh",
 					"name": "HL7 other aliases (complete)",
-					"description": "Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated 2021-07-13 13:28:48 by https://github.com/FSHSchool/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
+					"description": "Aliases for all code systems defined at https://terminology.hl7.org/codesystems.html that are not part of V2 or V3. Generated 2021-07-13 13:28:48 by https://github.com/FHIR/FSHOnline-Examples/tree/main/Scripts/Aliases/HL7.ipynb. Leading $ signs are optional but are useful for visually distinguishing aliases from other names.",
 					"type": "file"
 				},
 				{

--- a/index.json
+++ b/index.json
@@ -1,5 +1,5 @@
 {
-	"timestamp": "2024-09-13T09:48:20-04:00",
+	"timestamp": "2024-09-13T13:51:16+00:00",
 	"children": [
 		{
 			"name": "Aliases",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "FSHOnline-Examples",
   "version": "1.0.0",
-  "description": "This repository contains a set of FHIR Shorthand examples that are displayed on [FSH Online](https://fshschool.org/FSHOnline/).  The goal of these examples is to demonstrate how to do things in FSH.",
+  "description": "This repository contains a set of FHIR Shorthand examples that are displayed on [FSH Online](https://fshonline.fshschool.org/).  The goal of these examples is to demonstrate how to do things in FSH.",
   "main": "index.js",
   "scripts": {
     "build": "node manifest.js",
@@ -9,15 +9,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/FSHSchool/FSHOnline-Examples.git"
+    "url": "git+https://github.com/FHIR/FSHOnline-Examples.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/FSHSchool/FSHOnline-Examples/issues"
+    "url": "https://github.com/FHIR/FSHOnline-Examples/issues"
   },
-  "homepage": "https://github.com/FSHSchool/FSHOnline-Examples#readme",
+  "homepage": "https://github.com/FHIR/FSHOnline-Examples#readme",
   "dependencies": {
     "moment": "^2.29.1"
   }


### PR DESCRIPTION
**Description:** Update links related to moving FSHOnline-Examples to the GitHub organization.

This PR should not be merged until _after_ the repository has been moved to the github.com/fhir organization.

**Related Issue:** N/A
